### PR TITLE
Update FAH packaging

### DIFF
--- a/ensembler/refinement.py
+++ b/ensembler/refinement.py
@@ -714,7 +714,7 @@ def refine_explicit_md(
         ff='amber99sbildn',
         water_model='tip3p',
         nonbondedMethod = app.PME, # nonbonded method
-        cutoff = 1.0*unit.nanometers, # nonbonded cutoff
+        cutoff = 0.9*unit.nanometers, # nonbonded cutoff
         constraints = app.HBonds, # bond constrains
         rigidWater = True, # rigid water
         removeCMMotion = False, # remove center-of-mass motion


### PR DESCRIPTION
This change updates the FAH packaging scripts to
* Ensure PME parameters are set explicitly.  Addresses https://github.com/pandegroup/openmm/issues/1108, https://github.com/FoldingAtHome/openmm-core/issues/64, https://github.com/FoldingAtHome/openmm-core/issues/67
* Ensure `MonteCarloBarostat` temperature is the same as specified temperature for integrator