### PR TITLE
fix os.symlink call for gather_templates --structure_paths - use abspath

### DIFF
--- a/ensembler/initproject.py
+++ b/ensembler/initproject.py
@@ -440,7 +440,7 @@ def attempt_symlink_structure_files(pdbid, project_structures_dir, structure_dir
             if file_exists_and_not_empty(structure_filepath) > 0:
                 if os.path.exists(project_structure_filepath):
                     os.remove(project_structure_filepath)
-                os.symlink(structure_filepath, project_structure_filepath)
+                os.symlink(os.path.abspath(structure_filepath), os.path.abspath(project_structure_filepath))
                 break
 
 

--- a/ensembler/tests/test_initproject.py
+++ b/ensembler/tests/test_initproject.py
@@ -10,6 +10,7 @@ import ensembler.core
 import ensembler.uniprot
 from ensembler.utils import enter_temp_dir, get_installed_resource_filename
 from ensembler.tests.integrationtest_utils import integrationtest_context
+import shutil
 
 
 @attr('unit')
@@ -108,6 +109,18 @@ def test_attempt_symlink_structure_files():
         ensembler.initproject.attempt_symlink_structure_files(pdbid, '.', structure_paths, structure_type)
         assert os.path.exists(project_pdb_filepath)
 
+@attr('unit')
+def test_attempt_symlink_structure_files_relative_path():
+    pdbid = '4CFE'
+    structure_path = get_installed_resource_filename(os.path.join('tests', 'resources', pdbid + '.pdb.gz'))
+    with enter_temp_dir():
+        os.mkdir('pdb')
+        os.mkdir('manual_input')
+        shutil.copy(structure_path, 'manual_input')
+        structure_type = 'pdb'
+        project_pdb_filepath = os.path.join('pdb', pdbid + '.pdb.gz')
+        ensembler.initproject.attempt_symlink_structure_files(pdbid, '.', ['manual_input'], structure_type)
+        assert os.path.exists(project_pdb_filepath)
 
 @attr('unit')
 def test_log_unique_domain_names():


### PR DESCRIPTION
Fixes https://github.com/choderalab/ensembler/issues/73

(that's adding a trailing new line at the end in the diff)
